### PR TITLE
Remove the host on unmount

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,9 @@ const unmount = async (options: SingleSpaAureliaFrameworkOptions, props: SingleS
     aurelia['root'].detached();
     aurelia['root'].unbind();
 
+    aurelia['host'] = null;
+    aurelia['hostConfigured'] = false;
+
     log(`${props.name} has been unmounted!`, options.debug);
 
     return Promise.resolve();


### PR DESCRIPTION
As discussed in #1 we ran into an issue where an Aurelia app couldn't be mounted again after it had been previously unmounted. While debugging I noticed that the `aurelia` instance was still attached to the previous DOM element which had already been removed from the DOM, thus the UI wasn't rendering properly.

This PR explicitly removes the `host` element from the `aurelia` instance and sets `hostConfigured` to `false` so that those things are reinitialised properly.