### PR TITLE
Deactivate and reset the router on unmount

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,12 @@ const unmount = async (options: SingleSpaAureliaFrameworkOptions, props: SingleS
     aurelia.root.detached();
     aurelia.root.unbind();
 
+    const viewModel: any = aurelia.root.viewModel;
+    if (viewModel && viewModel.router) {
+        viewModel.router.deactivate();
+        viewModel.router.reset();
+    }
+
     aurelia.host = null;
     aurelia.hostConfigured = false;
 


### PR DESCRIPTION
As discussed in #4 it seems that if an Aurelia app hosted in single-spa is using Aurelia's router functionality it is not properly cleaned up when the app is unmounted. This causes unwanted behaviour, because the location is being reset when navigating away from an application.

Fixes #4 