### PR TITLE
Don't expose private types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,14 +9,14 @@ export type SingleSpaProps = {
 };
 
 export type SingleSpaAureliaFrameworkOptions = {
-    getInstance: () => AureliaInstance;
-    configure: (aurelia: AureliaInstance) => Promise<void>;
-    bootstrap: (configure: (aurelia: AureliaInstance) => Promise<void>) => Promise<void>;
+    getInstance: () => Aurelia;
+    configure: (aurelia: Aurelia) => Promise<void>;
+    bootstrap: (configure: (aurelia: Aurelia) => Promise<void>) => Promise<void>;
     component: string;
     debug: boolean;
 };
 
-export type AureliaInstance = Merge<
+type AureliaInstance = Merge<
     Aurelia,
     {
         root: Controller;
@@ -78,7 +78,7 @@ const mount = async (options: SingleSpaAureliaFrameworkOptions, props: SingleSpa
 };
 
 const unmount = async (options: SingleSpaAureliaFrameworkOptions, props: SingleSpaProps): Promise<void> => {
-    const aurelia: AureliaInstance = options.getInstance();
+    const aurelia: AureliaInstance = options.getInstance() as AureliaInstance;
 
     aurelia.root.view.removeNodes();
     aurelia.root.detached();


### PR DESCRIPTION
As discussed in #3 the 1.0.10 release required users to change types in their TypeScript files to match types that were essentially internal to this package, rather than relying on the public types from Aurelia itself. I've modified the typings so that only the existing public Aurelia types are exposed outside this package and the internal type is only used internally.

With this change I am getting a compile error in my single-spa app that uses this package:

```
[tsl] ERROR in /Users/jonathanm/Projects/demos/single-spa/scheduling/src/main.single-spa.ts(52,24)
      TS2322: Type 'import("/Users/jonathanm/Projects/demos/single-spa/scheduling/node_modules/aurelia-framework/dist/aurelia-framework").Aurelia' is not assignable to type 'import("/Users/jonathanm/Projects/open-source/rr-wfm/single-spa-aurelia-framework/node_modules/aurelia-framework/dist/aurelia-framework").Aurelia'.
  The types of 'container.setHandlerCreatedCallback' are incompatible between these types.
    Type '<TBase, TImpl extends import("/Users/jonathanm/Projects/demos/single-spa/scheduling/node_modules/aurelia-dependency-injection/dist/aurelia-dependency-injection").Impl<TBase> = import("/Users/jonathanm/Projects/demos/single-spa/scheduling/node_modules/aurelia-dependency-injection/dist/aurelia-dependency-injection").I...' is not assignable to type '<TBase, TImpl extends import("/Users/jonathanm/Projects/open-source/rr-wfm/single-spa-aurelia-framework/node_modules/aurelia-dependency-injection/dist/aurelia-dependency-injection").Impl<TBase> = import("/Users/jonathanm/Projects/open-source/rr-wfm/single-spa-aurelia-framework/node_modules/aurelia-dependency-injecti...'.
      Types of parameters 'onHandlerCreated' and 'onHandlerCreated' are incompatible.
        Types of parameters 'handler' and 'handler' are incompatible.
          Type 'InvocationHandler<TBase | TImpl, Impl<TBase | TImpl>, Args<TBase | TImpl>>' is not assignable to type 'InvocationHandler<TBase, TImpl, TArgs>'.
            Types of property 'fn' are incompatible.
              Type 'DependencyCtorOrFunctor<TBase | TImpl, Impl<TBase | TImpl>, Args<TBase | TImpl>>' is not assignable to type 'DependencyCtorOrFunctor<TBase, TImpl, TArgs>'.
                Type 'DependencyCtor<TBase | TImpl, Impl<TBase | TImpl>, Args<TBase | TImpl>>' is not assignable to type 'DependencyCtorOrFunctor<TBase, TImpl, TArgs>'.
                  Type 'DependencyCtor<TBase | TImpl, Impl<TBase | TImpl>, Args<TBase | TImpl>>' is not assignable to type 'DependencyCtor<TBase, TImpl, TArgs>'.
                    Types of parameters 'args' and 'args' are incompatible.
                      Type 'TArgs' is not assignable to type 'Args<TBase | TImpl>'.
                        Type 'Args<TBase>' is not assignable to type 'Args<TBase | TImpl>'.
                          Type 'CtorArgs<TBase>' is not assignable to type 'Args<TBase | TImpl>'.
                            Type 'any[] | unknown[]' is not assignable to type 'Args<TBase | TImpl>'.
                              Type 'any[]' is not assignable to type 'Args<TBase | TImpl>'.
                                Type 'any[]' is not assignable to type 'FuncArgs<TImpl>'.
                                  Type 'CtorArgs<TBase>' is not assignable to type 'FuncArgs<TImpl>'.
                                    Type 'TArgs' is not assignable to type 'FuncArgs<TImpl>'.
                                      Type 'Args<TBase>' is not assignable to type 'FuncArgs<TImpl>'.
                                        Type 'CtorArgs<TBase>' is not assignable to type 'FuncArgs<TImpl>'.
                                          Type 'any[] | unknown[]' is not assignable to type 'FuncArgs<TImpl>'.
                                            Type 'any[]' is not assignable to type 'FuncArgs<TImpl>'.
```

My guess is that this is caused by the fact that the package isn't being installed from npm, but directly from my machine. I didn't have this issue with version 1.0.9 and the types are now essentially the same, so that's the only explantation I could think of.